### PR TITLE
Add Sentry integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 language: python
+python:
+- "3.4"
 env:
 - CONDAENV=python3.4
 services:

--- a/genotype_to_model/__init__.py
+++ b/genotype_to_model/__init__.py
@@ -1,6 +1,19 @@
 import logging
 import sys
 
+from raven import Client
+from raven.conf import setup_logging
+from raven.handlers.logging import SentryHandler
+
+from . import settings
+
+
 logger = logging.getLogger('genotype-to-model')
 logger.addHandler(logging.StreamHandler(stream=sys.stdout))  # Logspout captures logs from stdout if docker containers
 logger.setLevel(logging.INFO)
+
+# Configure Raven to capture warning logs
+raven_client = Client(settings.SENTRY_DSN)
+handler = SentryHandler(raven_client)
+handler.setLevel(logging.WARNING)
+setup_logging(handler)

--- a/genotype_to_model/app.py
+++ b/genotype_to_model/app.py
@@ -1,4 +1,5 @@
 import asyncio
+from aiohttp import web
 import aiohttp_cors
 from venom.rpc import Service, Venom
 from venom.rpc.comms.aiohttp import create_app
@@ -8,6 +9,8 @@ from venom.fields import MapField, String
 from venom.message import Message
 from genotype_to_model import logger
 from genotype_to_model.ice_client import IceClient
+
+from .middleware import raven_middleware
 
 
 class GeneMessage(Message):
@@ -33,7 +36,7 @@ class AnnotationService(Service):
 venom = Venom(version='0.1.0', title='GenesToReactions')
 venom.add(AnnotationService)
 venom.add(ReflectService)
-app = create_app(venom)
+app = create_app(venom, web.Application(middlewares=[raven_middleware]))
 # Configure default CORS settings.
 cors = aiohttp_cors.setup(app, defaults={
     "*": aiohttp_cors.ResourceOptions(

--- a/genotype_to_model/middleware.py
+++ b/genotype_to_model/middleware.py
@@ -1,0 +1,12 @@
+from . import raven_client
+
+
+async def raven_middleware(app, handler):
+    """aiohttp middleware which captures any uncaught exceptions to Sentry before re-raising"""
+    async def middleware_handler(request):
+        try:
+            return await handler(request)
+        except Exception:
+            raven_client.captureException()
+            raise
+    return middleware_handler

--- a/genotype_to_model/settings.py
+++ b/genotype_to_model/settings.py
@@ -1,4 +1,4 @@
 import os
 
-GENOMICS_API = os.environ['GENOMICS_API']
+# GENOMICS_API = os.environ['GENOMICS_API']
 SENTRY_DSN = os.environ.get('SENTRY_DSN', '')

--- a/genotype_to_model/settings.py
+++ b/genotype_to_model/settings.py
@@ -1,3 +1,4 @@
 import os
 
 GENOMICS_API = os.environ['GENOMICS_API']
+SENTRY_DSN = os.environ.get('SENTRY_DSN', '')

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytest-asyncio==0.5.0
 pytest-cov==2.4.0
 nose
 git+https://github.com/DD-DeCaF/ice-communication.git#egg=ice
+raven==6.4.0


### PR DESCRIPTION
Adds Raven to capture error events to Sentry

- aiohttp middleware logs uncaught exceptions, and re-raises
- log events of `warning` or higher level
- set Travis python version to 3.4 to avoid conflict
- comment unused `GENOMICS_API` setting